### PR TITLE
Add logger initialization

### DIFF
--- a/cmd/klevr-agent/main.go
+++ b/cmd/klevr-agent/main.go
@@ -699,6 +699,8 @@ func deleteFile(path string){
 }
 
 func main() {
+	common.InitLogger(common.NewLoggerEnv())
+
 	/// check the cli command with required options
 	Check_variable()
 	///// Requirement package check


### PR DESCRIPTION
It's used before the logger is init, causing an error. 
Initialize the logger at the time of application execution.